### PR TITLE
Remove pybind for removed functions

### DIFF
--- a/python/pybind_module.cpp
+++ b/python/pybind_module.cpp
@@ -107,27 +107,27 @@ PYBIND11_MODULE(pystereoglue, m) {
         .def_readwrite("final_optimization_settings", &stereoglue::RANSACSettings::finalOptimizationSettings);
         
     // Expose the function to Python
-    m.def("estimateHomographyGravity", &estimateHomographyGravity, "A function that performs homography estimation from point correspondences.",
-        py::arg("lafs1"),
-        py::arg("lafs2"),
-        py::arg("matches"),
-        py::arg("scores"),
-        py::arg("intrinsics_src"),
-        py::arg("intrinsics_dst"),
-        py::arg("image_sizes"),
-        py::arg("gravity_src") = Eigen::Matrix3d::Identity(),
-        py::arg("gravity_dst") = Eigen::Matrix3d::Identity(),
-        py::arg("config") = stereoglue::RANSACSettings());
+//    m.def("estimateHomographyGravity", &estimateHomographyGravity, "A function that performs homography estimation from point correspondences.",
+//        py::arg("lafs1"),
+//        py::arg("lafs2"),
+//        py::arg("matches"),
+//        py::arg("scores"),
+//        py::arg("intrinsics_src"),
+//        py::arg("intrinsics_dst"),
+//        py::arg("image_sizes"),
+//        py::arg("gravity_src") = Eigen::Matrix3d::Identity(),
+//        py::arg("gravity_dst") = Eigen::Matrix3d::Identity(),
+//        py::arg("config") = stereoglue::RANSACSettings());
         
-    m.def("estimateHomographySimple", &estimateHomographySimple, "A function that performs homography estimation from point correspondences.",
-        py::arg("lafs1"),
-        py::arg("lafs2"),
-        py::arg("matches"),
-        py::arg("scores"),
-        py::arg("intrinsics_src"),
-        py::arg("intrinsics_dst"),
-        py::arg("image_sizes"),
-        py::arg("config") = stereoglue::RANSACSettings());
+//    m.def("estimateHomographySimple", &estimateHomographySimple, "A function that performs homography estimation from point correspondences.",
+//        py::arg("lafs1"),
+//        py::arg("lafs2"),
+//        py::arg("matches"),
+//        py::arg("scores"),
+//        py::arg("intrinsics_src"),
+//        py::arg("intrinsics_dst"),
+//        py::arg("image_sizes"),
+//        py::arg("config") = stereoglue::RANSACSettings());
         
     // Expose the function to Python
     m.def("estimateFundamentalMatrix", &estimateFundamentalMatrix, "A function that performs fundamental matrix estimation from point correspondences.",


### PR DESCRIPTION
When importing pystereoglue I get the following error because the binding for the removed functions are still there:
`ImportError: /home/dawars/miniconda3/envs/sdfstudio/lib/python3.10/site-packages/pystereoglue.cpython-310-x86_64-linux-gnu.so: undefined symbol: _Z24estimateHomographySimpleRKN5Eigen6MatrixIdLin1ELin1ELi0ELin1ELin1EEES3_S3_S3_RKNS0_IdLi3ELi3ELi0ELi3ELi3EEES6_RKSt6vectorIdSaIdEERN10stereoglue14RANSACSettingsE`

This PR comments out those binds